### PR TITLE
Add paper-item-icon-active-color

### DIFF
--- a/themes/ios-dark-mode.yaml
+++ b/themes/ios-dark-mode.yaml
@@ -10,7 +10,7 @@ ios-dark-mode:
   primary-background-color: "#2c2c2e"  # systemGray5 dark mode
   secondary-background-color: rgba(25, 25, 25, 0.7)
   divider-color: "#98989d"  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
+  accent-color: var(--primary-color)
   # Text
   primary-text-color: "#FFF"
   secondary-text-color: "#d3d3d3"
@@ -61,7 +61,7 @@ ios-dark-mode:
   # Other
   paper-dialog-background-color: rgba(55, 55, 55, 0.6)
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  paper-item-icon-active-color: "#F9C536"
+  paper-item-icon-active-color: var(--primary-color)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   # Custom
   mcg-title-letter-spacing: .15em

--- a/themes/ios-dark-mode.yaml
+++ b/themes/ios-dark-mode.yaml
@@ -61,6 +61,7 @@ ios-dark-mode:
   # Other
   paper-dialog-background-color: rgba(55, 55, 55, 0.6)
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  paper-item-icon-active-color: "#F9C536"
   more-info-header-background: rgba(25, 25, 25, 0.5)
   # Custom
   mcg-title-letter-spacing: .15em


### PR DESCRIPTION
Which applies to icon when e.g. in glance card, binary_sensor is 'on'.