### PR TITLE
Add system font stack

### DIFF
--- a/themes/ios-dark-mode.yaml
+++ b/themes/ios-dark-mode.yaml
@@ -12,6 +12,14 @@ ios-dark-mode:
   divider-color: "#98989d"  # from Apple systemGray dark mode
   accent-color: rgba(255, 159, 9, 1)
   # Text
+  primary-font-family: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif"
+  paper-font-common-base_-_font-family: "var(--primary-font-family)"
+  paper-font-common-code_-_font-family: "var(--primary-font-family)"
+  paper-font-body1_-_font-family: "var(--primary-font-family)"
+  paper-font-subhead_-_font-family: "var(--primary-font-family)"
+  paper-font-headline_-_font-family: "var(--primary-font-family)"
+  paper-font-caption_-_font-family: "var(--primary-font-family)"
+  paper-font-title_-_font-family: "var(--primary-font-family)"
   primary-text-color: "#FFF"
   secondary-text-color: "#d3d3d3"
   text-primary-color: "#FFF"


### PR DESCRIPTION
So iOS/macOS system font (San Francisco) will be used on Apple platforms, which looks even more at-home. 😊