### PR TITLE
adding card editor background colour value 

### DIFF
--- a/themes/ios-dark-mode.yaml
+++ b/themes/ios-dark-mode.yaml
@@ -56,6 +56,7 @@ ios-dark-mode:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  code-editor-background-color: var(--disabled-text-color)
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
   paper-toggle-button-checked-bar-color: "#484848"


### PR DESCRIPTION
As of 0.115, the code editor background colour defaults to 'card-background-color', but this is practically the same colour as some of the text, making it hard to read. This changes that to a dark grey which is fitting with the theme but allows you to see all code