### PR TITLE
Update labels for text field

### DIFF
--- a/themes/ios-dark-mode.yaml
+++ b/themes/ios-dark-mode.yaml
@@ -84,6 +84,7 @@ ios-dark-mode:
   # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
   mdc-text-field-fill-color: var(--card-background-color)
   mdc-text-field-ink-color: var(--primary-text-color)
+  mdc-text-field-label-ink-color: var(--primary-text-color)
   mdc-select-ink-color: var(--primary-text-color)
   mdc-select-fill-color: var(--card-background-color)
   mdc-select-label-ink-color: var(--primary-text-color)


### PR DESCRIPTION
Makes the label for text fields readable.

The labels are black and with this change they are readable.
See below for an example.
![44A9F049-77A1-4A34-9FFD-BE352B639A52](https://user-images.githubusercontent.com/13658422/157100181-4ab6b6c9-10e1-4310-9a35-b8d8f0650e35.jpeg)
